### PR TITLE
Add docs for deploying Django apps to PaaS

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,8 +15,8 @@ pages:
     - 'Deploying a Static Site': 'deploying_apps/deploying_static_sites.md'
     - 'Deploying a Ruby on Rails App': 'deploying_apps/deploying_rails.md'
 #    - 'Deploying Flask': 'deploying_apps/deploying_flask.md'
-#    - 'Deploying Django': 'deploying_apps/deploying_django.md'
     - 'Deploying a Node.js App': 'deploying_apps/deploying_node_js.md'
+    - 'Deploying a Django App': 'deploying_apps/deploying_django.md'
     - 'Using Travis CI': 'deploying_apps/travis_ci.md'
     - 'Logging': 'deploying_apps/logging.md'
 - Deploying Backing Services:


### PR DESCRIPTION
To test:

Build locally with mkdocs to see layout and check that formatting is
correct. Note that how Mkdocs interprets markdown is not the same as
e.g. github

Installing mkdocs: http://www.mkdocs.org/#installation
Then run 'mkdocs build' to serve at localhost:8000.

Please check that all steps are correct and allow you to correctly
deploy a Django app. Please look for instructions that may not apply to
every Django app as these were only tested with a very simple skeleton
app.
