### PR TITLE
packages.json is not needed for detection

### DIFF
--- a/docs/deploying_apps/deploying_node_js.md
+++ b/docs/deploying_apps/deploying_node_js.md
@@ -19,8 +19,6 @@ These steps assume you have already carried out the setup process explained in t
 
 3. Include an npm ``package.json`` file to specify dependencies. The file should also specify a `start` command used to launch the app.
   
-    The presence of this file is essential to have the application detected as Node.js.
-
     This is an example of a minimal ``package.json`` file:
 
         


### PR DESCRIPTION
## What

Remove a line that stated that packages.json is required for detection of the
correct buildpack.
## Why

The current wording is inaccurate and might mean that users form an incorrect mental model of how Cloud Foundry works.
## How to review

There's no change to to the procedure itself, so the review process should be someone independently reviewing the [nodejs buildpack](https://docs.cloudfoundry.org/buildpacks/node/index.html) and [buildpack detection docs](https://docs.cloudfoundry.org/buildpacks/detection.html) and making sure my understanding of the behaviour is correct
## Who can review

Anyone but @bleach
