### PR TITLE
Document that Docker image deployment is not enabled

### DIFF
--- a/docs/deploying_apps/limitations.md
+++ b/docs/deploying_apps/limitations.md
@@ -1,0 +1,8 @@
+
+## Deploying Docker images is not currently enabled
+
+Cloud Foundry supports pushing a [Docker](https://www.docker.com/) image as an app. 
+
+This feature is *not* currently enabled on the Government PaaS because allowing deployment from Docker images, where the root filesystem is controlled by the tenant, raises additional security concerns: see [this note from the CF developers](https://github.com/cloudfoundry/diego-design-notes/blob/c59e475020a22e244c6074f89c45b55f7b1e2867/docker-support.md#docker-in-a-multi-tenant-world) for more details.
+
+We may enable support for Docker images in the future. If you would like to be able to push Docker images, please contact our support team at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk), providing details of your use case.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ pages:
     - 'Deploying a Ruby on Rails App': 'deploying_apps/deploying_rails.md'
     - 'Deploying a Node.js App': 'deploying_apps/deploying_node_js.md'
     - 'Deploying a Django App': 'deploying_apps/deploying_django.md'
+    - 'Limitations': 'deploying_apps/limitations.md'
 - Deploying Backing Services:
     - 'Services Overview': 'deploying_services/index.md'
     - 'Creating a PostgreSQL Service': 'deploying_services/postgres.md'


### PR DESCRIPTION
What

This adds a Limitations section to the docs, with a page explaining that pushing Docker images is not supported, as per: https://www.pivotaltracker.com/story/show/126121955 for details

How to review

Build in mkdocs. Review 'Limitations' section.

Check that this explanation would be satisfying to a developer who is trying to work out why Docker deploys don't work. 

Check links/mailto address. 

Who can review

Anyone but Ben
