### PR TITLE
Remove duplicate Python from list of languages

### DIFF
--- a/docs/getting_started/before_you_start.md
+++ b/docs/getting_started/before_you_start.md
@@ -7,7 +7,6 @@ To be hosted by Government PaaS, your application must:
     * Go
     * Nodejs
     * Java
-    * Python
     * PHP
     * Python
     * Ruby


### PR DESCRIPTION
This is in there twice.
