### PR TITLE
Fix css so that site expands to width of browser

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,0 +1,8 @@
+.wy-nav-content {
+  max-width: 100% !important;
+}
+
+code {
+  line-height: 125% !important;
+}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Government Platform as a Service documentation
 theme: readthedocs
+extra_css: [css/extra.css]
 pages:
 - Overview:
     - 'Government Platform as a Service (PaaS)': 'index.md'


### PR DESCRIPTION
## What

We're using mkdocs for our own documentation and noticed a problem with the way that the docs are displayed in wide browsers. As we'd already fixed this issue for our own docs, I thought I'd send you a PR with the same fix.

Add extra css file so that the documentation will expand to the full width of the browser rather than the hardcoded maxwidth of 800px which is the default.
Fix issue with code blocks sometimes being rendered at strange heights. 
## How to review

Use this branch to generate the docs, and the confirm that the docs expand to the width of the browser.
## Who can review

Anyone on the GDS PaaS team,
