### PR TITLE
Remove duplicate limitations page

### DIFF
--- a/docs/deploying_apps/limitations.md
+++ b/docs/deploying_apps/limitations.md
@@ -1,8 +1,0 @@
-
-## Deploying Docker images is not currently enabled
-
-Cloud Foundry supports pushing a [Docker](https://www.docker.com/) image as an app. 
-
-This feature is *not* currently enabled on the Government PaaS because allowing deployment from Docker images, where the root filesystem is controlled by the tenant, raises additional security concerns: see [this note from the CF developers](https://github.com/cloudfoundry/diego-design-notes/blob/c59e475020a22e244c6074f89c45b55f7b1e2867/docker-support.md#docker-in-a-multi-tenant-world) for more details.
-
-We may enable support for Docker images in the future. If you would like to be able to push Docker images, please contact our support team at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk), providing details of your use case.


### PR DESCRIPTION
## What

Remove `docs/deploying_apps/limitations.md` left behind by accident in #17 and only contains information that is in `docs/getting_started/limitations.md`

We discussed briefly in slack if we needed to redirect the old page to the new
and decided it was unlikely that many people would have links saved that
pointed to the old page.
## How to review

Check that we haven't lost documentation. and that everything is still OK.
## Who can review

Anyone but @bleach 
