### PR TITLE
Automate broken link checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site/
 env/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+  - "2.7"
+install: "pip install -r requirements.txt"
+script: ./check_links.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Government PaaS Developer Docs
 
-
-
 This project uses [MkDocs][]. It is automatically built and hosted by [Read
 the Docs][] at the following URL:
 
@@ -21,6 +19,9 @@ process locally.
 
 [virtualenv]: https://virtualenv.pypa.io/en/latest/
 
+    virtualenv env
+    source ./env/bin/activate
+
 To install the dependencies:
 
     pip install -Ur requirements.txt
@@ -34,3 +35,20 @@ To preview your changes locally run:
 Then visit:
 
 - http://127.0.0.1:8000
+
+## Testing
+
+The only test at the moment is for broken internal links.
+You can test manually using
+
+    ./check_links.sh
+
+The script starts a mkdocs server of its own, and kills it afterwards.
+
+The link checker will check whether internal links point to pages which actually exist.
+It won't check anchors (https://github.com/wummel/linkchecker/issues/557) and won't do much more than check well-formedness for mailto links.
+It won't currently check links to external sites, but we can enable that functionality if we wish to later on.
+
+[Travis][] runs `./check_links.sh` on each commit.
+
+[Travis]: https://travis-ci.org/alphagov/paas-developer-docs

--- a/check_links.sh
+++ b/check_links.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# build docs site
+mkdocs build --clean
+
+# start serving docs site
+mkdocs serve&
+
+# wait for docs site to be up and running
+while ! nc -z localhost 8000; do
+  sleep 1
+done
+
+# check links
+linkchecker http://localhost:8000
+res=$?
+
+pkill mkdocs
+
+exit $res

--- a/docs/deploying_apps/index.md
+++ b/docs/deploying_apps/index.md
@@ -37,5 +37,5 @@ After deployment, you can increase the running instances to two using:
 * Your app should not write to local storage. Cloud Foundry local storage is ephemeral and can be deleted at any time.
 * You may need to set environment variables for your app to work. All configuration information should be stored in environment variables, not in the code. 
 * Instances will be restarted if they [exceed memory limits](/managing_apps/quotas/).
-* Proper [logging](/deploying_apps/logging/) might require special libraries/configuration for your app.
+* Proper [logging](/managing_apps/logging/) might require special libraries/configuration for your app.
 

--- a/docs/deploying_services/index.md
+++ b/docs/deploying_services/index.md
@@ -8,7 +8,7 @@ Currently, the only service available is the [PostgreSQL database service](/depl
 
 Some services (including ``postgres``) are considered paid services. Your organization may not have the ability to use paid services enabled. Access to paid services can either be enabled or disabled based on your [organisation quota](/managing_apps/quotas/).
 
-If you try to create a service and receive an error stating "service instance cannot be created because paid service plans are not allowed", please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](gov-uk-paas-support@digital.cabinet-office.gov.uk).
+If you try to create a service and receive an error stating "service instance cannot be created because paid service plans are not allowed", please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
 ## Accessing services
 

--- a/docs/deploying_services/postgres.md
+++ b/docs/deploying_services/postgres.md
@@ -10,7 +10,7 @@ Currently, Government PaaS offers a ``postgres`` service which is available with
 
 The number in the plan name (in this case, ``9.5``) is the PostgreSQL version.
 
-``postgres`` is considered a paid service. Paid services may not be enabled on your account. If you try to create a service and receive an error stating "service instance cannot be created because paid service plans are not allowed", please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](gov-uk-paas-support@digital.cabinet-office.gov.uk).
+``postgres`` is considered a paid service. Paid services may not be enabled on your account. If you try to create a service and receive an error stating "service instance cannot be created because paid service plans are not allowed", please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
 
 To create a service and bind it to your app:
@@ -102,7 +102,7 @@ The PaaS PostgreSQL service is currently provided by Amazon Web Services RDS. Ea
 
 For more details, see the [Amazon RDS Maintenance documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html) [external page].
 
-If you need to know the time of your maintenance window, please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](gov-uk-paas-support@digital.cabinet-office.gov.uk). Times will be from 22:00 to 06:00 UTC. We will add the ability to set the time of the maintenance window in a future version of Government PaaS.
+If you need to know the time of your maintenance window, please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk). Times will be from 22:00 to 06:00 UTC. We will add the ability to set the time of the maintenance window in a future version of Government PaaS.
 
 ## PostgreSQL service backup
 
@@ -112,7 +112,7 @@ Backups are taken nightly and data is retained for 7 days.
 
 If you need to restore data to an earlier state, we can restore to any point from 5 minutes to 7 days ago, with a resolution of one second. Data can be restored to a new PostgreSQL service instance running in parallel, or it can replace the existing service instance.
 
-Please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](gov-uk-paas-support@digital.cabinet-office.gov.uk) to arrange the restore process or if you need further information about the backup process. We will need approval from your organization manager if restoring will involve overwriting data.
+Please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to arrange the restore process or if you need further information about the backup process. We will need approval from your organization manager if restoring will involve overwriting data.
 
 Note that data restore will not be available in the event of an RDS outage affecting the entire Amazon availability zone.
 
@@ -130,7 +130,7 @@ During failover, there will be an outage period (from tens of seconds to a few m
 
 See the [Amazon RDS documentation on the failover process](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) for more details.
 
-If you wish to test how your app deals with a failover, we can trigger one for you. Please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](gov-uk-paas-support@digital.cabinet-office.gov.uk) to arrange this.
+If you wish to test how your app deals with a failover, we can trigger one for you. Please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to arrange this.
 
 ## Read replicas
 
@@ -138,6 +138,6 @@ Amazon RDS has the capability to provide a read replica: a read-only copy of you
 
 See the [Amazon RD documentation on read replicas](https://aws.amazon.com/rds/details/read-replicas/) to learn more.
 
-ThE Government PaaS doesn't currently support read replicas, but if you think you would find them useful, please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](gov-uk-paas-support@digital.cabinet-office.gov.uk), providing details of your use case.
+ThE Government PaaS doesn't currently support read replicas, but if you think you would find them useful, please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk), providing details of your use case.
 
 

--- a/docs/managing_apps/scaling.md
+++ b/docs/managing_apps/scaling.md
@@ -6,7 +6,7 @@ Note that the maximum resources you can use will be limited by your organization
 
 from the command line.
 
-If you are anticipating a spike in demand for a service hosted on the Government PaaS, please contact us well in advance at <gov-uk-paas-support@digital.cabinet-office.gov.uk>.
+If you are anticipating a spike in demand for a service hosted on the Government PaaS, please contact us well in advance at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
 ##Increasing instances
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,11 @@ blockdiag==1.5.3
 certifi==2015.9.6.2
 click==5.1
 funcparserlib==0.3.6
+linkchecker==9.3
+
+# https://github.com/wummel/linkchecker/issues/649
+requests==2.9.1
+
 livereload==2.4.0
 mkdocs==0.14.0
 seqdiag==0.9.5


### PR DESCRIPTION
## What

Added the python linkchecker tool (https://github.com/wummel/linkchecker)
to allow automatic checking for broken links, configured for internal links only at present.

Fixed broken links it discovered.

Added travis buildfile to allow this to be automated as part of our CI.
## How to review

in a local checkout, run `./check_links.sh` and verify it finds no broken links.
Deliberately break a link and verify a second run finds the broken link.
Merge this PR.
Verify the Travis build runs and finds no broken links (https://travis-ci.org/alphagov/paas-developer-docs).
## Who can review

Anyone but @benhyland
