### PR TITLE
Document IP whitelist restrictions

### DIFF
--- a/docs/getting_started/limitations.md
+++ b/docs/getting_started/limitations.md
@@ -1,12 +1,12 @@
 While the Government PaaS is built using Cloud Foundry technology, we don't support all Cloud Foundry features. This section explains some Cloud Foundry features that are not enabled, as well as some limitations of the beta phase.
 
-## IP whitelisting
+## IP restrictions
 
-We currently only allow command line client connections from whitelist IP addresses. When you sign up to use the PaaS, you must tell us the IPs or IP ranges you want us to whitelist. 
+We currently only accept command line client connections from a list of approved IP addresses (a 'whitelist'). When you sign up to use the PaaS, you must tell us the IPs or IP ranges you and your developers will connect from, so we can add them to our whitelist. 
 
-You can [view the list of allowed IPs](https://github.com/alphagov/paas-cf/blob/master/terraform/prod.tfvars#L9). If you want us to allow additional IPs, please email us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](gov-uk-paas-support@digital.cabinet-office.gov.uk).
+You can view [the list of allowed IPs](https://github.com/alphagov/paas-cf/blob/master/terraform/prod.tfvars#L9). If you want us to allow additional IPs, please email us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
-Note that the whitelist only limits use of the command line client; it does not restrict access to deployed apps, which are available to everyone.
+Note that IP restrictions only apply to use of the command line client; there is no restriction on access to your deployed apps, which are available to everyone.
 
 ## Custom buildpacks are not supported
 

--- a/docs/getting_started/limitations.md
+++ b/docs/getting_started/limitations.md
@@ -1,5 +1,13 @@
 While the Government PaaS is built using Cloud Foundry technology, we don't support all Cloud Foundry features. This section explains some Cloud Foundry features that are not enabled, as well as some limitations of the beta phase.
 
+## IP whitelisting
+
+We currently only allow command line client connections from whitelist IP addresses. When you sign up to use the PaaS, you must tell us the IPs or IP ranges you want us to whitelist. 
+
+You can [view the list of allowed IPs](https://github.com/alphagov/paas-cf/blob/master/terraform/prod.tfvars#L9). If you want us to allow additional IPs, please email us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](gov-uk-paas-support@digital.cabinet-office.gov.uk).
+
+Note that the whitelist only limits use of the command line client; it does not restrict access to deployed apps, which are available to everyone.
+
 ## Custom buildpacks are not supported
 
 Cloud Foundry uses buildpacks to provide runtime and framework support for applications in different languages. 
@@ -34,7 +42,7 @@ In the meantime, we suggest that you use a [blue-green deployment process](https
 
 During the beta period, there may be occasional brief periods where API access is unavailable during a platform update, causing commands sent from the command line client to fail. 
 
-If you find that a valid command is failing and the error message does not explain the problem, please wait 5 minutes before trying the command again. If the error persists for more than 5 minutes, it is unlikely to be caused by a platform update and you should contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
+If you find that a valid command is failing and the error message does not explain the problem, please wait 5 minutes before trying the command again. If the error persists for more than 5 minutes, it is unlikely to be caused by a platform update and you should contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).  
 
 We are working on a fix to prevent the interruption of API access when we update the platform.
 

--- a/docs/getting_started/quick_setup_guide.md
+++ b/docs/getting_started/quick_setup_guide.md
@@ -4,6 +4,8 @@ Government PaaS is currently in private beta.
 
 If your organisation is taking part in the private beta and you need an account, or you'd like to find about taking part in the beta, please contact us by emailing [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
+We currently use an IP whitelist to limit who can access the PaaS to deploy and manage apps (note that this does not affect access to deployed apps, which are visible to everyone). As part of the setup process, you will need to provide us with a list of all the IPs you and your developers will use to access the PaaS. You can [check which IPs are whitelisted here](https://github.com/alphagov/paas-cf/blob/master/terraform/prod.tfvars#L9).
+
 In order to provide you with an account, we need to store some personal data about you. Please see [our Privacy Policy](/getting_started/privacy) for details.
 
 ## Setting up the command line
@@ -37,6 +39,15 @@ Government PaaS uses a hosting technology called Cloud Foundry. As a tenant (tha
     Your `USERNAME` is your email address your account was created with.
 
     You will then be prompted to enter your password, which should have been sent to you by email (subject "Welcome to the Government PaaS").
+
+    If your login fails with a message like this:
+
+    ```
+    FAILED
+    Error performing request: Get https://api.cloud.service.gov.uk/v2/info: EOF
+    ```
+
+    and your internet connection is otherwise working, the most likely cause is that your IP address is not on [our whitelist](https://github.com/alphagov/paas-cf/blob/master/terraform/prod.tfvars#L9). Please contact support and ask to be whitelisted.
 
 4. **It's important for security that you now change your password**. Run:
 

--- a/docs/getting_started/quick_setup_guide.md
+++ b/docs/getting_started/quick_setup_guide.md
@@ -4,7 +4,7 @@ Government PaaS is currently in private beta.
 
 If your organisation is taking part in the private beta and you need an account, or you'd like to find about taking part in the beta, please contact us by emailing [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
-We currently use an IP whitelist to limit who can access the PaaS to deploy and manage apps (note that this does not affect access to deployed apps, which are visible to everyone). As part of the setup process, you will need to provide us with a list of all the IPs you and your developers will use to access the PaaS. You can [check which IPs are whitelisted here](https://github.com/alphagov/paas-cf/blob/master/terraform/prod.tfvars#L9).
+We currently restrict which IP addresses are allowed to access the PaaS to deploy and manage apps. As part of the setup process, you will need to provide us with a list of all the IPs you and your developers will use to access the PaaS. You can [check our whitelist of allowed IPs here](https://github.com/alphagov/paas-cf/blob/master/terraform/prod.tfvars#L9).
 
 In order to provide you with an account, we need to store some personal data about you. Please see [our Privacy Policy](/getting_started/privacy) for details.
 

--- a/docs/troubleshooting/cli.md
+++ b/docs/troubleshooting/cli.md
@@ -1,0 +1,16 @@
+## EOF errors due to not being on IP whitelist
+
+We use an IP whitelist to limit who can access the PaaS to deploy apps.
+
+If you have set up the command line client as explained in the [Quick Setup Guide section](/getting_started/quick_setup_guide/#setting-up-the-command-line), and you find that commands you try are constantly met with an EOF error similar to this:
+
+```
+FAILED
+Error performing request: Get https://api.cloud.service.gov.uk/v2/info: EOF
+```
+
+the most likely reason is that your IP is not on the whitelist.
+
+You can [view the list of allowed IPs](https://github.com/alphagov/paas-cf/blob/master/terraform/prod.tfvars#L9) to check if yours is whitelisted. If not, please email us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](gov-uk-paas-support@digital.cabinet-office.gov.uk).
+
+Note that the whitelist only limits use of the command line client; it does not restrict access to deployed apps, which are available to everyone.

--- a/docs/troubleshooting/cli.md
+++ b/docs/troubleshooting/cli.md
@@ -1,16 +1,16 @@
-## EOF errors due to not being on IP whitelist
+## EOF errors due to IP restrictions
 
-We use an IP whitelist to limit who can access the PaaS to deploy apps.
+We restrict which IP addresses are allowed to access the PaaS through the command line client.
 
-If you have set up the command line client as explained in the [Quick Setup Guide section](/getting_started/quick_setup_guide/#setting-up-the-command-line), and you find that commands you try are constantly met with an EOF error similar to this:
+If you have set up the command line client as explained in the [Quick Setup Guide section](/getting_started/quick_setup_guide/#setting-up-the-command-line), and you find that any commands you try are met with an EOF error similar to this:
 
 ```
 FAILED
 Error performing request: Get https://api.cloud.service.gov.uk/v2/info: EOF
 ```
 
-the most likely reason is that your IP is not on the whitelist.
+the most likely reason is that your IP address is not on our 'whitelist' of allowed addresses.
 
-You can [view the list of allowed IPs](https://github.com/alphagov/paas-cf/blob/master/terraform/prod.tfvars#L9) to check if yours is whitelisted. If not, please email us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](gov-uk-paas-support@digital.cabinet-office.gov.uk).
+You can [view the list of allowed IPs](https://github.com/alphagov/paas-cf/blob/master/terraform/prod.tfvars#L9) to check if yours is whitelisted. If not, please email us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
 Note that the whitelist only limits use of the command line client; it does not restrict access to deployed apps, which are available to everyone.

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -1,6 +1,5 @@
 
-
-## Current logs
+If your app deployment is failing and it's not clear why from the command line client messages, you should consult the logs.
 
 For log messages to be captured by Cloud Foundry, your application should be writing them to `STDOUT`/`STDERR`, rather than a log file.
 
@@ -29,7 +28,7 @@ Running ``cf events`` shows you when an app starts, stops, restarts, or crashes 
 
 ## Further information
 
-For more information about logging and troubleshooting, see the Cloud Foundry documentation:
+For more information about logging and troubleshooting app deployment, see the following sections of the Cloud Foundry documentation:
 
 * [Information about the log format](https://docs.cloudfoundry.org/devguide/deploy-apps/streaming-logs.html) [external link]
 * [Viewing your application's logs](https://docs.cloudfoundry.org/devguide/deploy-apps/streaming-logs.html#view) [external link]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,8 @@ pages:
     - 'Services Overview': 'deploying_services/index.md'
     - 'Using a PostgreSQL Service': 'deploying_services/postgres.md'
 - Troubleshooting:
-    - 'Troubleshooting': 'troubleshooting/index.md'
+    - 'App Deployment Problems': 'troubleshooting/index.md'
+    - 'CLI Client Problems': 'troubleshooting/cli.md'
 - Managing Apps:
     - 'Scaling Apps' : 'managing_apps/scaling.md'
     - 'Quotas': 'managing_apps/quotas.md'


### PR DESCRIPTION
This update adds an explanation of the IP whitelist to limit CLI access
to PaaS. See Pivotal story below for details.

If tenant's IP is not whitelisted, they can't use the PaaS at all, and
this is known to have been a problem for several users, so I have added
warnings in the Quick Setup guide, the Troubleshooting section, and in
the Limitations section.

To test: check that explanation is accurate and easy to understand.
Check that link to whitelist is accurate and confirm we should point
users to this information. In "Troubleshooting", check that the
description of what happens if you try to use the client without being
whitelisted is correct.

Pivotal story:
#131354965

Currently we only allow a limited set of IP addresses to access the CF
endpoints (CF, loggregator, UAA).
This is a temporary way of reducing our attack surface until we are
able to do some more work to secure the system from attack.
Things we could and possibly should document for tenants:
that their deployed applications are public and not whitelisted
that the restrictions will prevent them from running cf commands from
an IP address not on the list
that this is a temporary measure
that we can add IP addresses to the whitelist if required by tenants