### PR TITLE
Warn users not to set PORT; troubleshooting if they have

### DIFF
--- a/docs/deploying_apps/env_variables.md
+++ b/docs/deploying_apps/env_variables.md
@@ -24,7 +24,13 @@ then you should do the equivalent command with ``cf set-env``:
 
 ##System-provided environment variables
 
-There are two system-provided environment variables which contain information in JSON format.
+As well as environment variables you set yourself, there are a number of system-provided variables which give you information about configuration details handled by the PaaS: the port on which the application is listening, the maximum memory each instance can use, the external IP address of the instance, and so on.
+
+Do not attempt to change the values of these system-provided variables with the CLI or your app's code.
+
+For a full list, see Cloud Foundry's [Cloud Foundry Environment Variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html) [external link] documentation.
+
+Two important variables for initial setup are:
 
 * VCAP_SERVICES contains details (including credentials) of any backing services bound to the app
 * VCAP_APPLICATION provides details of the currently running application (for example, language runtime version)
@@ -38,6 +44,3 @@ If your app connects to a backing service, you may need to have it parse VCAP_SE
 However, some buildpacks will do this for you automatically. See the deploy instructions for the language/framework you are using for details.
 
 
-##Further reading
-
-For more information, see Cloud Foundry's [Cloud Foundry Environment Variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html) [external link] documentation.

--- a/docs/troubleshooting/port.md
+++ b/docs/troubleshooting/port.md
@@ -1,0 +1,22 @@
+## PORT environment variable error
+
+The PORT environment variable is system-provided, and you should not attempt to set it yourself.
+
+If you are trying to set any environment variable and you get an error like this:
+
+```
+FAILED Server error, status code: 400, error code: 100001, message: The app is invalid: environment_variables cannot set PORT
+```
+
+the cause is that the value of PORT has been changed from the system-provided value.
+
+Running these commands should fix the problem:
+
+```
+cf unset-env myapp PORT
+cf restage myapp
+```
+
+where `myapp` is the name of the affected app instance.
+
+Make sure that the app does not attempt to set the PORT variable.


### PR DESCRIPTION
Changes to address DeskPRO ticket 1798 where a tenant had problems
caused by the PORT variable being changed from the system-provided
value. We are not clear how that happened.

Fixes:
* in env_variables, put more information about system provided
variables and say not to change them yourself; provide link to CF docs
about this early in relevant section instead of under a separate
"Further reading" heading
* add Troubleshooting page about how to fix it if PORT gets set

To test:

check content, especially that steps to unset PORT are correct and can
be run by a tenant rather than the PaaS team