### PR TITLE
Tweak jenkins instructions

### DIFF
--- a/docs/deploying_apps/jenkins.md
+++ b/docs/deploying_apps/jenkins.md
@@ -56,6 +56,8 @@ Further information can be found on the [Cloud Foundry plugin's wiki page](https
 
 Before you do this, make sure you first [set up the credentials plugin](/deploying_apps/jenkins/#setting-up-the-credentials-plugin).
 
+Note that currently, this approach briefly exposes the password via the process command line. If this risk is not acceptable, please use the Cloud Foundry plugin described above. The Cloud Foundry project is aware of the problem and we expect they will provide a more secure login mechanism soon.
+
 1. In the Jenkins web interface, click on **Manage Jenkins**, then **Manage Plugins**.
 2. Click on the **Available** tab and find "Credentials Binding Plugin". Check the box to select the plugin, then click either **Install without restart** or **Download now and install after restart** at the bottom of the interface.
 3. In your build configuration, select the **Use secret text(s) or file(s)**checkbox in the "Build Environment" section.

--- a/docs/deploying_apps/jenkins.md
+++ b/docs/deploying_apps/jenkins.md
@@ -67,9 +67,10 @@ Once this is set up, any shell scripts you configure in Jenkins will have the cr
 A basic 'execute shell' buildstep would look like this:
 
 ```
-# Important: always set $CF_HOME to a location within your project.
-# We set it above the workspace to not conflict with your repository.
-export CF_HOME="${WORKSPACE}/../"
+# Set CF_HOME per-job so that jobs do not share or overwrite each others' credentials.
+# Remember to use a local subdirectory for your code to avoid including the credentials in your app.
+export CF_HOME="${WORKSPACE}"
+cd my-code
 
 cf api https://api.cloud.service.gov.uk
 

--- a/docs/deploying_apps/jenkins.md
+++ b/docs/deploying_apps/jenkins.md
@@ -13,7 +13,7 @@ Setting up custom scripts requires a bit more configuration, but allows you to f
 
 ## Setting up the credentials plugin
 
-To install the credentials plugin:
+To install the credentials plugin manually:
 
 1. In the Jenkins web interface, click on **Manage Jenkins**, then **Manage Plugins**.
 2. Click on the **Installed** tab and check if "Credentials Plugin" is listed. If it's listed, skip the next step.
@@ -36,7 +36,7 @@ You can now go on to either:
 
 ## Setting up the Cloud Foundry plugin
 
-Before you do this, make sure you first [set up the credentials plugin](/deploying_apps/jenkins/#setting-up-the-credentials-plugin).
+Before you do this, make sure you first [set up the credentials plugin](/deploying_apps/jenkins/#setting-up-the-credentials-plugin). To install it manually:
 
 1. In the Jenkins web interface, click on **Manage Jenkins**, then **Manage Plugins**.
 2. Click on the **Available** tab and find "Cloud Foundry Plugin". Check the box to select the plugin, then click either **Install without restart** or **Download now and install after restart** at the bottom of the interface.
@@ -57,6 +57,8 @@ Further information can be found on the [Cloud Foundry plugin's wiki page](https
 Before you do this, make sure you first [set up the credentials plugin](/deploying_apps/jenkins/#setting-up-the-credentials-plugin).
 
 Note that using the custom scripts approach exposes the password via the process command line, so it can be read by other processes running on the same machine. If this risk is not acceptable, please use the Cloud Foundry plugin described above. The Cloud Foundry project is aware of the problem and we expect they will provide a more secure login mechanism soon.
+
+The custom scripts approach needs the Jenkins credentials binding plugin. To install it manually:
 
 1. In the Jenkins web interface, click on **Manage Jenkins**, then **Manage Plugins**.
 2. Click on the **Available** tab and find "Credentials Binding Plugin". Check the box to select the plugin, then click either **Install without restart** or **Download now and install after restart** at the bottom of the interface.

--- a/docs/deploying_apps/jenkins.md
+++ b/docs/deploying_apps/jenkins.md
@@ -56,7 +56,7 @@ Further information can be found on the [Cloud Foundry plugin's wiki page](https
 
 Before you do this, make sure you first [set up the credentials plugin](/deploying_apps/jenkins/#setting-up-the-credentials-plugin).
 
-Note that currently, this approach briefly exposes the password via the process command line. If this risk is not acceptable, please use the Cloud Foundry plugin described above. The Cloud Foundry project is aware of the problem and we expect they will provide a more secure login mechanism soon.
+Note that using the custom scripts approach exposes the password via the process command line, so it can be read by other processes running on the same machine. If this risk is not acceptable, please use the Cloud Foundry plugin described above. The Cloud Foundry project is aware of the problem and we expect they will provide a more secure login mechanism soon.
 
 1. In the Jenkins web interface, click on **Manage Jenkins**, then **Manage Plugins**.
 2. Click on the **Available** tab and find "Credentials Binding Plugin". Check the box to select the plugin, then click either **Install without restart** or **Download now and install after restart** at the bottom of the interface.


### PR DESCRIPTION
Some improvements to Jenkins instructions based on input from Ben Hyland.

1. Acknowledge that the instructions give a manual method and there are other ways (but no need to go into more detail about this)

2. Warn that custom scripting method exposes password locally

3. Clearer advice on setting CF_HOME