### PR TITLE
Explain specifying number of instances in manifest

### DIFF
--- a/docs/deploying_apps/deploying_django.md
+++ b/docs/deploying_apps/deploying_django.md
@@ -123,3 +123,19 @@ Then you'll need to add a `DATABASES` setting. It's best to add this to the `set
 Your `local_settings.py` file will override this when you're working locally.
 
 The `Procfile` configuration provided in the section above will automatically apply database migrations.
+
+##Adding more instances
+
+For a production app, you should run at least two instances of the app to ensure availability.
+
+You can add another instance by running:
+
+``cf scale APPNAME -i 2``
+
+or by adding this to the manifest and then pushing the app again:
+
+```
+---
+  ...
+  instances: 2
+```

--- a/docs/deploying_apps/deploying_node_js.md
+++ b/docs/deploying_apps/deploying_node_js.md
@@ -59,6 +59,8 @@ This is the code for the example app we are going to use. It is a basic web serv
 
 See [Tips for Node.js Applications](https://docs.cloudfoundry.org/buildpacks/node/node-tips.html) [external link] in the Cloud Foundry documentation for more information.
 
+
+
 ##PostgreSQL setup with Node.js
 
 If your app depends on [backing services](/deploying_services/) such as PostgreSQL, it will need to parse the `VCAP_SERVICES` environment variable to get required details, such as service URLs and credentials.
@@ -102,3 +104,18 @@ You should also remember to include dependencies for any service bindings in ``p
     }
     ```
 
+##Adding more instances
+
+For a production app, you should run at least two instances of the app to ensure availability.
+
+You can add another instance by running:
+
+``cf scale APPNAME -i 2``
+
+or by adding this to the manifest and then pushing the app again:
+
+```
+---
+  ...
+  instances: 2
+```

--- a/docs/deploying_apps/deploying_rails.md
+++ b/docs/deploying_apps/deploying_rails.md
@@ -127,11 +127,22 @@ Note that the only database service currently supported by PaaS is PostgreSQL. I
 
 Your app should now be live at `https://APPNAME.cloudapps.digital`!
 
-For a production service, you should run at least two instances of the app to ensure availability.
+##Adding more instances
 
-You can add another instance of your app by running:
+For a production app, you should run at least two instances of the app to ensure availability.
+
+You can add another instance by running:
 
 ``cf scale APPNAME -i 2``
+
+or by adding this to the manifest and then pushing the app again:
+
+```
+---
+  ...
+  instances: 2
+```
+
 
 ## Web servers
 

--- a/docs/deploying_apps/deploying_static_sites.md
+++ b/docs/deploying_apps/deploying_static_sites.md
@@ -62,3 +62,10 @@ You can add another instance of this static app by running:
 
 ``cf scale APPNAME -i 2``
 
+or by adding this to the manifest and pushing again:
+
+```
+---
+  ...
+  instances: 2
+```

--- a/docs/deploying_apps/index.md
+++ b/docs/deploying_apps/index.md
@@ -27,7 +27,13 @@ The app should now be live at `https://APPNAME.cloudapps.digital`.
 
 There are many options available when you ``push`` an app. You can optionally set them in a ``manifest.yml`` file in the directory from which you are running the ``push`` command. See the Cloud Foundry documentation on [Deploying with Application Manifests](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) [external link] for details.
 
-For a production app, you should run at least two instances to ensure availability.
+For a production app, you should run at least two instances to ensure availability. You can specify this in the manifest by adding:
+
+```
+---
+  ...
+  instances: 2
+```
 
 After deployment, you can increase the running instances to two using:
 

--- a/docs/managing_apps/scaling.md
+++ b/docs/managing_apps/scaling.md
@@ -17,6 +17,14 @@ For example, this command sets the number of running instances to five:
 
 ``cf scale APPNAME -i 5``
 
+You can add the number of instances to start when the app is pushed to the manifest:
+
+```
+---
+  ...
+  instances: 2
+```
+
 For a production app, you should always have at least two running instances.
 
 ##Increasing memory and disk space


### PR DESCRIPTION
We mention you should have 2 instances for production apps and mention "cf scale" but not putting "instances:" in the manifest. Seems sensible to mention both.